### PR TITLE
Feature/intra block allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,5 +50,5 @@ include_directories(${TIGERC_SRC})
 
 # add cmake sub directories
 add_subdirectory(${TIGERC_SRC})
-# add_subdirectory(test)
-# add_subdirectory(lib/googletest)
+add_subdirectory(test)
+add_subdirectory(lib/googletest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.7 FATAL_ERROR)
 
 #set project name
-project(tigerc)
+project(tiger_ir)
 
 # set ANTLR visitor/listener
 set(CREATE_ANTLR_LISTENER FALSE)
@@ -13,7 +13,7 @@ set(PARSER_NAME tigerIr)
 
 # TODO: find a way to use the variables from one subdirectory in another
 #set(LEXER_OUTPUT_DIR ${CMAKE_SOURCE_DIR}/build/src/${LEXER_NAME})
-#set(PARSER_OUTPUT_DIR ${CMAKE_SOURCE_DIR}/build/src/${PARSER_NAME})
+set(PARSER_OUTPUT_DIR ${CMAKE_SOURCE_DIR}/build/src/${PARSER_NAME})
 
 # compiler must be 11 or 14
 set(CMAKE_CXX_STANDARD 11)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,9 +52,9 @@ add_executable(${BIN_NAME} main.cpp
 
 target_link_libraries(${BIN_NAME} ${ANTLR4_STATIC_LIBRARIES})
 
-# #create static lib from src/ and generated CXX files
-# #this is used to link to the test executable
-# add_library(${LIB_NAME} STATIC ${SOURCES}
-# 			${ANTLR_TigerLexer_CXX_OUTPUTS}
-# 			${ANTLR_TigerParser_CXX_OUTPUTS}
-# 			)
+#create static lib from src/ and generated CXX files
+#this is used to link to the test executable
+add_library(${LIB_NAME} STATIC ${SOURCES}
+			# ${ANTLR_TigerLexer_CXX_OUTPUTS}
+			${ANTLR_TigerParser_CXX_OUTPUTS}
+			)

--- a/src/CodeGenerator.cpp
+++ b/src/CodeGenerator.cpp
@@ -1,7 +1,7 @@
 #include "CodeGenerator.h"
 
 
-CodeGenerator::CodeGenerator(Module * m)
+CodeGenerator::CodeGenerator(Module* m)
 {
     mod = m;
 }

--- a/src/CodeGenerator.h
+++ b/src/CodeGenerator.h
@@ -1,10 +1,9 @@
 #include "Module.h"
 
 
-
 class CodeGenerator{
-    Module * mod;
+    Module* mod;
     public:
-        CodeGenerator(Module * m);
+        CodeGenerator(Module* m);
 
 };

--- a/src/Function.h
+++ b/src/Function.h
@@ -12,10 +12,10 @@
 class Function {
     std::string name; // function name
     DataType rtype;
-    std::vector<Instruction *> instructions; // vector of IR instructions in program order
+    std::vector<Instruction*> instructions; // vector of IR instructions in program order
     std::map<std::string, int> branchTargets; // maps each label in IR to the index of the following instruction
-    std::vector<Function *> subroutines; // any functions called by this function
-    Function * caller; // function that calls this function (NULL in the case of main)
+    std::vector<Function*> subroutines; // any functions called by this function
+    Function* caller; // function that calls this function (NULL in the case of main)
     std::deque<ProgramValue> floatList; // float variables used (comes from float-list in IR)
     std::deque<ProgramValue> intList; // int variables used
     std::map<std::string, ProgramValue> dtypeMap;
@@ -23,7 +23,7 @@ class Function {
 
     public:
         Function(std::string name_, DataType rtype_, std::deque<ProgramValue> floatList_, std::deque<ProgramValue> intList_);
-        void addInstruction(Instruction * instr);
+        void addInstruction(Instruction* instr);
         void addBranchTarget(std::string label);
 
 };

--- a/src/Instruction.cpp
+++ b/src/Instruction.cpp
@@ -4,7 +4,7 @@
 
 std::ostream& operator<<(std::ostream& out, const ValType vtype)
 {
-    const char * s=0;
+    const char* s=0;
     #define PROCESS_VAL(p) case(p): s = #p; break;
     switch(vtype)
     {
@@ -19,11 +19,9 @@ std::ostream& operator<<(std::ostream& out, const ValType vtype)
 }
 
 
-
-
 std::ostream& operator<<(std::ostream& out, const InstructionType instr)
 {
-    const char * s=0;
+    const char* s=0;
     #define PROCESS_VAL(p) case(p): s = #p; break;
     switch(instr)
     {
@@ -54,7 +52,6 @@ std::ostream& operator<<(std::ostream& out, const InstructionType instr)
     return out << s;
 }
 
-
 std::ostream& operator<<(std::ostream& out, const Instruction& instr)
 {
     out << instr.instruction << ", DEFINE: ";
@@ -66,12 +63,6 @@ std::ostream& operator<<(std::ostream& out, const Instruction& instr)
     
     return out;
 }
-
-
-
-
-
-
 
 Instruction::Instruction(InstructionType instruction_, std::vector<ProgramValue> define_, std::vector<ProgramValue> use_)
 {

--- a/src/Instruction.h
+++ b/src/Instruction.h
@@ -52,8 +52,9 @@ class Instruction {
     std::vector<ProgramValue> in; // in set - UPDATED BY LIVELINESS ANALYSIS
     std::vector<ProgramValue> out; // out set - UPDATED BY LIVELINESS ANALYSIS
     std::map<std::string, StorageLocation *> storageLocations; // map from variable names to storage locations
-    // UPDATED BY REGISTER ALLOCATOR
-    bool leader; // whether or not this instruction is the start of a basic block
+    // This should be set in the treeVisitor. 
+    // The register allocator will then use it when building the CFG.
+    bool isLeader; // whether or not this instruction is the start of a basic block
 
     public:
         Instruction(InstructionType instruction_, std::vector<ProgramValue> define_, std::vector<ProgramValue> use_);

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -1,7 +1,7 @@
 
 #include "Module.h"
 
-void Module::addFunction(Function * f)
+void Module::addFunction(Function* f)
 {
     functionSeq.push_back(f);
 }

--- a/src/Module.h
+++ b/src/Module.h
@@ -6,10 +6,10 @@
 
 class Module {
 
-    std::vector<Function *> functionSeq;
+    std::vector<Function*> functionSeq;
 
     public:
-        Function * getFunction(std::string name);
-        void addFunction(Function * f);
+        Function* getFunction(std::string name);
+        void addFunction(Function* f);
 
 };

--- a/src/ParseTree.cpp
+++ b/src/ParseTree.cpp
@@ -27,11 +27,11 @@ tiger::ParseTree::ParseTree(std::string irFileName_)
 bool tiger::ParseTree::visitTree()
 {
     visitor = new irVisitor();
-    visitor -> visit(tree);
+    visitor->visit(tree);
     return true;
 }
 
 Module * tiger::ParseTree::getModule()
 {
-    return visitor -> getModule();
+    return visitor->getModule();
 }

--- a/src/ParseTree.h
+++ b/src/ParseTree.h
@@ -16,7 +16,7 @@ namespace tiger {
 class ParseTree
 {
  private:
-	irVisitor * visitor;
+	irVisitor* visitor;
  	tiger::tigerIrLexer* lexer;
  	tiger::tigerIrParser* parser;
  	antlr4::ANTLRInputStream* tokenStream;
@@ -34,7 +34,7 @@ class ParseTree
  	antlr4::CommonTokenStream* getTokens() { return tokens; };
  	std::string getTigerFileName(){ return tigerFileName; };
  	std::string getIrFileName(){ return irFileName; };
-	Module * getModule();
+	Module* getModule();
 
  	bool visitTree();
 };

--- a/src/irVisitor.cpp
+++ b/src/irVisitor.cpp
@@ -1,5 +1,3 @@
-
-
 #include "irVisitor.h"
 
 
@@ -8,7 +6,7 @@ irVisitor::irVisitor()
     mod = new Module();
 }
 
-Module * irVisitor::getModule()
+Module* irVisitor::getModule()
 {
     return mod;
 }
@@ -17,23 +15,23 @@ Module * irVisitor::getModule()
 antlrcpp::Any irVisitor::visitFunction(tiger::tigerIrParser::FunctionContext *ctx){
 
     // get info about the function
-    std::deque<std::string> params = visit(ctx -> paramList());
-    DataType dtype = visit(ctx -> typeId());
-    std::string funcname = ctx -> ID(0) -> getText();
-    std::deque<ProgramValue> intList = visit(ctx -> varList(0));
-    std::deque<ProgramValue> floatList = visit(ctx -> varList(1));
+    std::deque<std::string> params = visit(ctx->paramList());
+    DataType dtype = visit(ctx->typeId());
+    std::string funcname = ctx->ID(0)->getText();
+    std::deque<ProgramValue> intList = visit(ctx->varList(0));
+    std::deque<ProgramValue> floatList = visit(ctx->varList(1));
     
     // create function object
     currentFunction = new Function(funcname, dtype, floatList, intList);
-    visit(ctx -> funcBody());
-    mod -> addFunction(currentFunction);
+    visit(ctx->funcBody());
+    mod->addFunction(currentFunction);
     return 0;
 
 }
 
 antlrcpp::Any irVisitor::visitParamListNonEmpty(tiger::tigerIrParser::ParamListNonEmptyContext *ctx){
     std::deque<std::string> paramList = visit(ctx ->paramListTail());
-    std::string param = visit(ctx -> param());
+    std::string param = visit(ctx->param());
     paramList.push_front(param);
     return paramList;
 }
@@ -45,7 +43,7 @@ antlrcpp::Any irVisitor::visitParamListEmpty(tiger::tigerIrParser::ParamListEmpt
 
 antlrcpp::Any irVisitor::visitParamListTailNonEmpty(tiger::tigerIrParser::ParamListTailNonEmptyContext *ctx){
     std::deque<std::string> paramList = visit(ctx ->paramListTail());
-    std::string param = visit(ctx -> param());
+    std::string param = visit(ctx->param());
     paramList.push_front(param);
     return paramList;
 }
@@ -56,36 +54,36 @@ antlrcpp::Any irVisitor::visitParamListTailEmpty(tiger::tigerIrParser::ParamList
 }
 
 antlrcpp::Any irVisitor::visitParam(tiger::tigerIrParser::ParamContext *ctx){
-    std::string id = ctx -> ID() -> getText();
+    std::string id = ctx->ID()->getText();
     return id;
 }
 
 // antlrcpp::Any irVisitor::visitTypeId(tiger::tigerIrParser::TypeIdContext *ctx){}
 
 antlrcpp::Any irVisitor::visitVarListExpand(tiger::tigerIrParser::VarListExpandContext *ctx){
-    std::deque<ProgramValue> varList = visit(ctx -> varList());
-    int size = visit(ctx -> arrayDeref());
+    std::deque<ProgramValue> varList = visit(ctx->varList());
+    int size = visit(ctx->arrayDeref());
     ValType vtype;
     if(size == 0)
         vtype=VAR;
     else if(size > 0)
         vtype=ARRAY;
 
-    ProgramValue pval = {vtype, UNKNOWN, ctx -> ID() -> getText(), size};
+    ProgramValue pval = {vtype, UNKNOWN, ctx->ID()->getText(), size};
     varList.push_front(pval);
     return varList;
 }
 
 antlrcpp::Any irVisitor::visitVarListSingle(tiger::tigerIrParser::VarListSingleContext *ctx){
     std::deque<ProgramValue> varList;
-    int size = visit(ctx -> arrayDeref());
+    int size = visit(ctx->arrayDeref());
     ValType vtype;
     if(size == 0)
         vtype=VAR;
     else if(size > 0)
         vtype=ARRAY;
 
-    ProgramValue pval = {vtype, UNKNOWN, ctx -> ID() -> getText(), size};
+    ProgramValue pval = {vtype, UNKNOWN, ctx->ID()->getText(), size};
     varList.push_front(pval);
     return varList;
 }
@@ -111,23 +109,23 @@ antlrcpp::Any irVisitor::visitTypeIdVoid(tiger::tigerIrParser::TypeIdVoidContext
 
 
 antlrcpp::Any irVisitor::visitValId(tiger::tigerIrParser::ValIdContext *ctx){
-    ProgramValue val = {VAR, UNKNOWN, ctx -> ID() -> getText(), 0};
+    ProgramValue val = {VAR, UNKNOWN, ctx->ID()->getText(), 0};
     return val;
 }
 
 antlrcpp::Any irVisitor::visitValIntLit(tiger::tigerIrParser::ValIntLitContext *ctx){
-    ProgramValue val = {LITERAL, INT, ctx -> INTLIT() -> getText(), 0};
+    ProgramValue val = {LITERAL, INT, ctx->INTLIT()->getText(), 0};
     return val;
 }
 
 antlrcpp::Any irVisitor::visitValFloatLit(tiger::tigerIrParser::ValFloatLitContext *ctx){
-    ProgramValue val = {LITERAL, FLOAT, ctx -> FLOATLIT() -> getText(), 0};
+    ProgramValue val = {LITERAL, FLOAT, ctx->FLOATLIT()->getText(), 0};
     return val;
 }
 
 
 antlrcpp::Any irVisitor::visitArrayDerefNonempty(tiger::tigerIrParser::ArrayDerefNonemptyContext *ctx){
-    return std::stoi(ctx -> INTLIT() -> getText());
+    return std::stoi(ctx->INTLIT()->getText());
 }
 
 antlrcpp::Any irVisitor::visitArrayDerefEmpty(tiger::tigerIrParser::ArrayDerefEmptyContext *ctx){
@@ -136,14 +134,14 @@ antlrcpp::Any irVisitor::visitArrayDerefEmpty(tiger::tigerIrParser::ArrayDerefEm
 
 
 antlrcpp::Any irVisitor::visitExprListContinue(tiger::tigerIrParser::ExprListContinueContext *ctx){
-    std::deque<ProgramValue> dq = visit(ctx -> exprList());
-    dq.push_front(visit(ctx -> val()));
+    std::deque<ProgramValue> dq = visit(ctx->exprList());
+    dq.push_front(visit(ctx->val()));
     return dq;
 }
 
 antlrcpp::Any irVisitor::visitExprListSingle(tiger::tigerIrParser::ExprListSingleContext *ctx){
     std::deque<ProgramValue> dq;
-    dq.push_back(visit(ctx -> val()));
+    dq.push_back(visit(ctx->val()));
     return dq;
 }
 
@@ -155,169 +153,169 @@ antlrcpp::Any irVisitor::visitExprListEmpty(tiger::tigerIrParser::ExprListEmptyC
 
 antlrcpp::Any irVisitor::visitAssign(tiger::tigerIrParser::AssignContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(0)));
+    lhs.push_back(visit(ctx->val(0)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(1)));
-    AssignInstruction * instr = new AssignInstruction(ASSIGN, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0]);
-    currentFunction -> addInstruction(instr);
+    rhs.push_back(visit(ctx->val(1)));
+    AssignInstruction* instr = new AssignInstruction(ASSIGN, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 
 antlrcpp::Any irVisitor::visitAdd(tiger::tigerIrParser::AddContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(2)));
+    lhs.push_back(visit(ctx->val(2)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(0)));
-    rhs.push_back(visit(ctx -> val(1)));
-    BinaryInstruction * instr = new BinaryInstruction(ADD, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction -> addInstruction(instr);
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(ADD, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitSub(tiger::tigerIrParser::SubContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(2)));
+    lhs.push_back(visit(ctx->val(2)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(0)));
-    rhs.push_back(visit(ctx -> val(1)));
-    BinaryInstruction * instr = new BinaryInstruction(SUB, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction -> addInstruction(instr);
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(SUB, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitMult(tiger::tigerIrParser::MultContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(2)));
+    lhs.push_back(visit(ctx->val(2)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(0)));
-    rhs.push_back(visit(ctx -> val(1)));
-    BinaryInstruction * instr = new BinaryInstruction(MULT, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction -> addInstruction(instr);
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(MULT, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitDiv(tiger::tigerIrParser::DivContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(2)));
+    lhs.push_back(visit(ctx->val(2)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(0)));
-    rhs.push_back(visit(ctx -> val(1)));
-    BinaryInstruction * instr = new BinaryInstruction(DIV, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction -> addInstruction(instr);
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(DIV, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitAnd_op(tiger::tigerIrParser::And_opContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(2)));
+    lhs.push_back(visit(ctx->val(2)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(0)));
-    rhs.push_back(visit(ctx -> val(1)));
-    BinaryInstruction * instr = new BinaryInstruction(AND, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction -> addInstruction(instr);
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(AND, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitOr_op(tiger::tigerIrParser::Or_opContext *ctx){
     std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx -> val(2)));
+    lhs.push_back(visit(ctx->val(2)));
     std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx -> val(0)));
-    rhs.push_back(visit(ctx -> val(1)));
-    BinaryInstruction * instr = new BinaryInstruction(OR, lhs, rhs);
-    instr -> setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction ->addInstruction(instr);
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(OR, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitGoto_op(tiger::tigerIrParser::Goto_opContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    BranchInstruction * instr = new BranchInstruction(GOTO, define, use);
-    instr -> setOperands(ctx -> ID() ->getText());
-    currentFunction ->addInstruction(instr);
+    BranchInstruction* instr = new BranchInstruction(GOTO, define, use);
+    instr->setOperands(ctx->ID()->getText());
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitBreq(tiger::tigerIrParser::BreqContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx -> val(0)));
-    use.push_back(visit(ctx -> val(1)));
-    BranchInstruction * instr = new BranchInstruction(BREQ, define, use);
-    instr -> setOperands(ctx -> ID() ->getText(), use[0], use[1]);
-    currentFunction ->addInstruction(instr);
+    use.push_back(visit(ctx->val(0)));
+    use.push_back(visit(ctx->val(1)));
+    BranchInstruction* instr = new BranchInstruction(BREQ, define, use);
+    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitBrneq(tiger::tigerIrParser::BrneqContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx -> val(0)));
-    use.push_back(visit(ctx -> val(1)));
-    BranchInstruction * instr = new BranchInstruction(BRNEQ, define, use);
-    instr -> setOperands(ctx -> ID() ->getText(), use[0], use[1]);
-    currentFunction ->addInstruction(instr);
+    use.push_back(visit(ctx->val(0)));
+    use.push_back(visit(ctx->val(1)));
+    BranchInstruction* instr = new BranchInstruction(BRNEQ, define, use);
+    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitBrlt(tiger::tigerIrParser::BrltContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx -> val(0)));
-    use.push_back(visit(ctx -> val(1)));
-    BranchInstruction * instr = new BranchInstruction(BRLT, define, use);
-    instr -> setOperands(ctx -> ID() ->getText(), use[0], use[1]);
-    currentFunction ->addInstruction(instr);
+    use.push_back(visit(ctx->val(0)));
+    use.push_back(visit(ctx->val(1)));
+    BranchInstruction* instr = new BranchInstruction(BRLT, define, use);
+    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitBrgt(tiger::tigerIrParser::BrgtContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx -> val(0)));
-    use.push_back(visit(ctx -> val(1)));
-    BranchInstruction * instr = new BranchInstruction(BRGT, define, use);
-    instr -> setOperands(ctx -> ID() ->getText(), use[0], use[1]);
-    currentFunction ->addInstruction(instr);
+    use.push_back(visit(ctx->val(0)));
+    use.push_back(visit(ctx->val(1)));
+    BranchInstruction* instr = new BranchInstruction(BRGT, define, use);
+    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitBrleq(tiger::tigerIrParser::BrleqContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx -> val(0)));
-    use.push_back(visit(ctx -> val(1)));
-    BranchInstruction * instr = new BranchInstruction(BRLEQ, define, use);
-    instr -> setOperands(ctx -> ID() ->getText(), use[0], use[1]);
-    currentFunction ->addInstruction(instr);
+    use.push_back(visit(ctx->val(0)));
+    use.push_back(visit(ctx->val(1)));
+    BranchInstruction* instr = new BranchInstruction(BRLEQ, define, use);
+    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitBrgeq(tiger::tigerIrParser::BrgeqContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx -> val(0)));
-    use.push_back(visit(ctx -> val(1)));
-    BranchInstruction * instr = new BranchInstruction(BRGEQ, define, use);
-    instr -> setOperands(ctx -> ID() ->getText(), use[0], use[1]);
-    currentFunction ->addInstruction(instr);
+    use.push_back(visit(ctx->val(0)));
+    use.push_back(visit(ctx->val(1)));
+    BranchInstruction* instr = new BranchInstruction(BRGEQ, define, use);
+    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitReturn_void(tiger::tigerIrParser::Return_voidContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define; 
-    ReturnInstruction * instr = new ReturnInstruction(RETURN_VOID, define, use);
-    instr -> setOperands();
-    currentFunction ->addInstruction(instr);
+    ReturnInstruction* instr = new ReturnInstruction(RETURN_VOID, define, use);
+    instr->setOperands();
+    currentFunction->addInstruction(instr);
     return 0;
 
 }
@@ -325,48 +323,48 @@ antlrcpp::Any irVisitor::visitReturn_void(tiger::tigerIrParser::Return_voidConte
 antlrcpp::Any irVisitor::visitReturn_nonvoid(tiger::tigerIrParser::Return_nonvoidContext *ctx){
     std::vector<ProgramValue> use;
     std::vector<ProgramValue> define;
-    use.push_back(visit(ctx -> val()));
+    use.push_back(visit(ctx->val()));
     ReturnInstruction * instr = new ReturnInstruction(RETURN_NONVOID, define, use);
-    instr -> setOperands(use[0]);
-    currentFunction ->addInstruction(instr);
+    instr->setOperands(use[0]);
+    currentFunction->addInstruction(instr);
     return 0;
 
 }
 
 antlrcpp::Any irVisitor::visitCall(tiger::tigerIrParser::CallContext *ctx){
-    std::deque<ProgramValue> queue = visit(ctx ->exprList());
-    std::string funcname = ctx -> ID() -> getText();
+    std::deque<ProgramValue> queue = visit(ctx->exprList());
+    std::string funcname = ctx->ID()->getText();
     std::vector<ProgramValue> define;
     std::vector<ProgramValue> use;
     for(ProgramValue p : queue)
         use.push_back(p);
-    CallInstruction * instr = new CallInstruction(CALL, define, use);
-    instr -> setOperands(funcname, queue);
-    currentFunction -> addInstruction(instr);
+    CallInstruction* instr = new CallInstruction(CALL, define, use);
+    instr->setOperands(funcname, queue);
+    currentFunction->addInstruction(instr);
     return 0;
 }
 
 antlrcpp::Any irVisitor::visitCallr(tiger::tigerIrParser::CallrContext *ctx){
     std::deque<ProgramValue> queue = visit(ctx ->exprList());
-    ProgramValue rval = visit(ctx -> val());
-    std::string funcname = ctx -> ID() -> getText();
+    ProgramValue rval = visit(ctx->val());
+    std::string funcname = ctx->ID()->getText();
     std::vector<ProgramValue> define;
     std::vector<ProgramValue> use;
     for(ProgramValue p : queue)
         use.push_back(p);
     define.push_back(rval);
-    CallInstruction * instr = new CallInstruction(CALL, define, use);
-    instr -> setOperands(funcname, queue, rval);
-    currentFunction -> addInstruction(instr);
+    CallInstruction* instr = new CallInstruction(CALL, define, use);
+    instr->setOperands(funcname, queue, rval);
+    currentFunction->addInstruction(instr);
     return 0;
 
 }
 
 
 antlrcpp::Any irVisitor::visitArray_store(tiger::tigerIrParser::Array_storeContext *ctx){
-    ProgramValue array = visit(ctx -> val(0));
-    ProgramValue index = visit(ctx -> val(1));
-    ProgramValue storeval = visit(ctx -> val(2));
+    ProgramValue array = visit(ctx->val(0));
+    ProgramValue index = visit(ctx->val(1));
+    ProgramValue storeval = visit(ctx->val(2));
     
     std::vector<ProgramValue> define;
     std::vector<ProgramValue> use;
@@ -374,17 +372,17 @@ antlrcpp::Any irVisitor::visitArray_store(tiger::tigerIrParser::Array_storeConte
     use.push_back(storeval);
     use.push_back(array);
 
-    ArrayInstruction * instr = new ArrayInstruction(ARRAY_STORE, define, use);
-    instr -> setOperands(array, storeval, index);
-    currentFunction -> addInstruction(instr);
+    ArrayInstruction* instr = new ArrayInstruction(ARRAY_STORE, define, use);
+    instr->setOperands(array, storeval, index);
+    currentFunction->addInstruction(instr);
     return 0;
 
 }
 
 antlrcpp::Any irVisitor::visitArray_load(tiger::tigerIrParser::Array_loadContext *ctx){
-    ProgramValue array = visit(ctx -> val(1));
-    ProgramValue index = visit(ctx -> val(2));
-    ProgramValue loadval = visit(ctx -> val(0));
+    ProgramValue array = visit(ctx->val(1));
+    ProgramValue index = visit(ctx->val(2));
+    ProgramValue loadval = visit(ctx->val(0));
     
     std::vector<ProgramValue> define;
     std::vector<ProgramValue> use;
@@ -392,26 +390,26 @@ antlrcpp::Any irVisitor::visitArray_load(tiger::tigerIrParser::Array_loadContext
     use.push_back(array);
     define.push_back(loadval);
 
-    ArrayInstruction * instr = new ArrayInstruction(ARRAY_LOAD, define, use);
-    instr -> setOperands(array, loadval, index);
-    currentFunction -> addInstruction(instr);
+    ArrayInstruction* instr = new ArrayInstruction(ARRAY_LOAD, define, use);
+    instr->setOperands(array, loadval, index);
+    currentFunction->addInstruction(instr);
     return 0;
 
 }
 
 antlrcpp::Any irVisitor::visitArray_assign(tiger::tigerIrParser::Array_assignContext *ctx){
     
-    ProgramValue array = visit(ctx -> val(0));
-    ProgramValue storeval = visit(ctx -> val(2));
+    ProgramValue array = visit(ctx->val(0));
+    ProgramValue storeval = visit(ctx->val(2));
     
     std::vector<ProgramValue> define;
     std::vector<ProgramValue> use;
     use.push_back(storeval);
     define.push_back(array);
 
-    ArrayInstruction * instr = new ArrayInstruction(ARRAY_ASSIGN, define, use);
-    instr -> setOperands(array, storeval);
-    currentFunction -> addInstruction(instr);
+    ArrayInstruction* instr = new ArrayInstruction(ARRAY_ASSIGN, define, use);
+    instr->setOperands(array, storeval);
+    currentFunction->addInstruction(instr);
     return 0;
 
 }
@@ -419,7 +417,7 @@ antlrcpp::Any irVisitor::visitArray_assign(tiger::tigerIrParser::Array_assignCon
 
 antlrcpp::Any irVisitor::visitLabel(tiger::tigerIrParser::LabelContext *ctx)
 {
-    currentFunction ->addBranchTarget(ctx -> ID() -> getText());
+    currentFunction->addBranchTarget(ctx->ID()->getText());
     return 0;
 }
 

--- a/src/irVisitor.cpp
+++ b/src/irVisitor.cpp
@@ -30,7 +30,7 @@ antlrcpp::Any irVisitor::visitFunction(tiger::tigerIrParser::FunctionContext *ct
 }
 
 antlrcpp::Any irVisitor::visitParamListNonEmpty(tiger::tigerIrParser::ParamListNonEmptyContext *ctx){
-    std::deque<std::string> paramList = visit(ctx ->paramListTail());
+    std::deque<std::string> paramList = visit(ctx->paramListTail());
     std::string param = visit(ctx->param());
     paramList.push_front(param);
     return paramList;
@@ -163,151 +163,69 @@ antlrcpp::Any irVisitor::visitAssign(tiger::tigerIrParser::AssignContext *ctx){
 }
 
 
-antlrcpp::Any irVisitor::visitAdd(tiger::tigerIrParser::AddContext *ctx){
-    std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx->val(2)));
-    std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx->val(0)));
-    rhs.push_back(visit(ctx->val(1)));
-    BinaryInstruction* instr = new BinaryInstruction(ADD, lhs, rhs);
-    instr->setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitAdd(tiger::tigerIrParser::AddContext *ctx)
+{
+    return visitBinInst<tiger::tigerIrParser::AddContext>(ctx, ADD);
 }
 
-antlrcpp::Any irVisitor::visitSub(tiger::tigerIrParser::SubContext *ctx){
-    std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx->val(2)));
-    std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx->val(0)));
-    rhs.push_back(visit(ctx->val(1)));
-    BinaryInstruction* instr = new BinaryInstruction(SUB, lhs, rhs);
-    instr->setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitSub(tiger::tigerIrParser::SubContext *ctx)
+{
+    return visitBinInst<tiger::tigerIrParser::SubContext>(ctx, SUB);
 }
 
-antlrcpp::Any irVisitor::visitMult(tiger::tigerIrParser::MultContext *ctx){
-    std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx->val(2)));
-    std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx->val(0)));
-    rhs.push_back(visit(ctx->val(1)));
-    BinaryInstruction* instr = new BinaryInstruction(MULT, lhs, rhs);
-    instr->setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitMult(tiger::tigerIrParser::MultContext *ctx)
+{
+    return visitBinInst<tiger::tigerIrParser::MultContext>(ctx, MULT);
 }
 
-antlrcpp::Any irVisitor::visitDiv(tiger::tigerIrParser::DivContext *ctx){
-    std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx->val(2)));
-    std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx->val(0)));
-    rhs.push_back(visit(ctx->val(1)));
-    BinaryInstruction* instr = new BinaryInstruction(DIV, lhs, rhs);
-    instr->setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitDiv(tiger::tigerIrParser::DivContext *ctx)
+{
+    return visitBinInst<tiger::tigerIrParser::DivContext>(ctx, DIV);
 }
 
-antlrcpp::Any irVisitor::visitAnd_op(tiger::tigerIrParser::And_opContext *ctx){
-    std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx->val(2)));
-    std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx->val(0)));
-    rhs.push_back(visit(ctx->val(1)));
-    BinaryInstruction* instr = new BinaryInstruction(AND, lhs, rhs);
-    instr->setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitAnd_op(tiger::tigerIrParser::And_opContext *ctx)
+{
+    return visitBinInst<tiger::tigerIrParser::And_opContext>(ctx, AND);
 }
 
-antlrcpp::Any irVisitor::visitOr_op(tiger::tigerIrParser::Or_opContext *ctx){
-    std::vector<ProgramValue> lhs; 
-    lhs.push_back(visit(ctx->val(2)));
-    std::vector<ProgramValue> rhs;
-    rhs.push_back(visit(ctx->val(0)));
-    rhs.push_back(visit(ctx->val(1)));
-    BinaryInstruction* instr = new BinaryInstruction(OR, lhs, rhs);
-    instr->setOperands(lhs[0], rhs[0], rhs[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitOr_op(tiger::tigerIrParser::Or_opContext *ctx)
+{
+    return visitBinInst<tiger::tigerIrParser::Or_opContext>(ctx, OR);
 }
 
-antlrcpp::Any irVisitor::visitGoto_op(tiger::tigerIrParser::Goto_opContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    BranchInstruction* instr = new BranchInstruction(GOTO, define, use);
-    instr->setOperands(ctx->ID()->getText());
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitGoto_op(tiger::tigerIrParser::Goto_opContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::Goto_opContext>(ctx, GOTO);
 }
 
-antlrcpp::Any irVisitor::visitBreq(tiger::tigerIrParser::BreqContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx->val(0)));
-    use.push_back(visit(ctx->val(1)));
-    BranchInstruction* instr = new BranchInstruction(BREQ, define, use);
-    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitBreq(tiger::tigerIrParser::BreqContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::BreqContext>(ctx, BREQ);
 }
 
-antlrcpp::Any irVisitor::visitBrneq(tiger::tigerIrParser::BrneqContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx->val(0)));
-    use.push_back(visit(ctx->val(1)));
-    BranchInstruction* instr = new BranchInstruction(BRNEQ, define, use);
-    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitBrneq(tiger::tigerIrParser::BrneqContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::BrneqContext>(ctx, BRNEQ);
 }
 
-antlrcpp::Any irVisitor::visitBrlt(tiger::tigerIrParser::BrltContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx->val(0)));
-    use.push_back(visit(ctx->val(1)));
-    BranchInstruction* instr = new BranchInstruction(BRLT, define, use);
-    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitBrlt(tiger::tigerIrParser::BrltContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::BrltContext>(ctx, BRLT);
 }
 
-antlrcpp::Any irVisitor::visitBrgt(tiger::tigerIrParser::BrgtContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx->val(0)));
-    use.push_back(visit(ctx->val(1)));
-    BranchInstruction* instr = new BranchInstruction(BRGT, define, use);
-    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitBrgt(tiger::tigerIrParser::BrgtContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::BrgtContext>(ctx, BRGT);
 }
 
-antlrcpp::Any irVisitor::visitBrleq(tiger::tigerIrParser::BrleqContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx->val(0)));
-    use.push_back(visit(ctx->val(1)));
-    BranchInstruction* instr = new BranchInstruction(BRLEQ, define, use);
-    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitBrleq(tiger::tigerIrParser::BrleqContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::BrleqContext>(ctx, BRLEQ);
 }
 
-antlrcpp::Any irVisitor::visitBrgeq(tiger::tigerIrParser::BrgeqContext *ctx){
-    std::vector<ProgramValue> use;
-    std::vector<ProgramValue> define; 
-    use.push_back(visit(ctx->val(0)));
-    use.push_back(visit(ctx->val(1)));
-    BranchInstruction* instr = new BranchInstruction(BRGEQ, define, use);
-    instr->setOperands(ctx->ID()->getText(), use[0], use[1]);
-    currentFunction->addInstruction(instr);
-    return 0;
+antlrcpp::Any irVisitor::visitBrgeq(tiger::tigerIrParser::BrgeqContext *ctx)
+{
+    return visitBrInst<tiger::tigerIrParser::BrgeqContext>(ctx, BRGEQ);
 }
 
 antlrcpp::Any irVisitor::visitReturn_void(tiger::tigerIrParser::Return_voidContext *ctx){
@@ -414,10 +332,33 @@ antlrcpp::Any irVisitor::visitArray_assign(tiger::tigerIrParser::Array_assignCon
 
 }
 
-
 antlrcpp::Any irVisitor::visitLabel(tiger::tigerIrParser::LabelContext *ctx)
 {
     currentFunction->addBranchTarget(ctx->ID()->getText());
     return 0;
 }
 
+template <class ctxType>
+antlrcpp::Any irVisitor::visitBinInst(ctxType *ctx, InstructionType instType)
+{
+    std::vector<ProgramValue> lhs; 
+    lhs.push_back(visit(ctx->val(2)));
+    std::vector<ProgramValue> rhs;
+    rhs.push_back(visit(ctx->val(0)));
+    rhs.push_back(visit(ctx->val(1)));
+    BinaryInstruction* instr = new BinaryInstruction(instType, lhs, rhs);
+    instr->setOperands(lhs[0], rhs[0], rhs[1]);
+    currentFunction->addInstruction(instr);
+    return 0;
+}
+
+template <class ctxType>
+antlrcpp::Any irVisitor::visitBrInst(ctxType *ctx, InstructionType instType)
+{
+    std::vector<ProgramValue> use;
+    std::vector<ProgramValue> define; 
+    BranchInstruction* instr = new BranchInstruction(instType, define, use);
+    instr->setOperands(ctx->ID()->getText());
+    currentFunction->addInstruction(instr);
+    return 0;
+}

--- a/src/irVisitor.h
+++ b/src/irVisitor.h
@@ -13,13 +13,13 @@
 
 
  class irVisitor : public tiger::tigerIrBaseVisitor {
-     Module * mod;
-     Function * currentFunction;
+     Module* mod;
+     Function* currentFunction;
 
      public:
         irVisitor();
 
-        Module * getModule();
+        Module* getModule();
 
         antlrcpp::Any visitFunction(tiger::tigerIrParser::FunctionContext *ctx);
 
@@ -91,7 +91,6 @@
 
         antlrcpp::Any visitCallr(tiger::tigerIrParser::CallrContext *ctx);
 
-        
         antlrcpp::Any visitArray_store(tiger::tigerIrParser::Array_storeContext *ctx);
 
         antlrcpp::Any visitArray_load(tiger::tigerIrParser::Array_loadContext *ctx);

--- a/src/irVisitor.h
+++ b/src/irVisitor.h
@@ -105,5 +105,11 @@
 
         antlrcpp::Any visitLabel(tiger::tigerIrParser::LabelContext *ctx);
 
+     private:
+        template <class ctxType>
+        antlrcpp::Any visitBinInst(ctxType *ctx, InstructionType instType);
+
+        template <class ctxType>
+        antlrcpp::Any visitBrInst(ctxType *ctx, InstructionType instType);
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,8 @@ int main(int argc, char* argv[]) {
 
     tiger::ParseTree * parseTree = new tiger::ParseTree(inputFile);
     
-    parseTree -> visitTree();
-    Module * mod = parseTree->getModule();
+    parseTree->visitTree();
+    Module* mod = parseTree->getModule();
 
     
     // if register allocation strategy is not naive

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+message(STATUS "Running test/ CMakeLists.txt")
+
+# set sources
+file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false *.h *.cpp)
+set(SOURCES ${TEST_SOURCES})
+
+# include generated files in project environment
+# include_directories(${LEXER_OUTPUT_DIR})
+include_directories(${PARSER_OUTPUT_DIR})
+
+# find_library(ANTLR_LIB 
+# 	NAMES libantlr4-runtime.a antlr4-runtime
+# 	PATHS ${ANTLR4_LIB_DIR}
+# 	)
+# message(${ANTLR_LIB})
+
+# add bin
+add_executable(${TEST_BIN_NAME} ${TEST_SOURCES})
+
+# add tests
+add_test(NAME ${TEST_BIN_NAME} COMMAND ${TEST_BIN_NAME})
+
+# link src library
+target_link_libraries(${TEST_BIN_NAME} PUBLIC ${LIB_NAME} gtest)
+
+message(STATUS "test/ CMakeLists.txt - done")

--- a/test/InstructionTest.cpp
+++ b/test/InstructionTest.cpp
@@ -1,0 +1,11 @@
+#include "gtest/gtest.h"
+#include "Instruction.h"
+
+//SEE: https://chromium.googlesource.com/external/github.com/pwnall/googletest/+/HEAD/googletest/docs/primer.md
+
+TEST(Instruction, test1) 
+{
+    // ir::Instruction* testInst = new ir::Instruction();
+
+    ASSERT_TRUE(true);
+}

--- a/test/IrEnumTest.cpp
+++ b/test/IrEnumTest.cpp
@@ -1,0 +1,11 @@
+#include "gtest/gtest.h"
+// #include "IrEnums.h"
+
+TEST(IrEnums, testBinAdd) 
+{
+    // ir::OpCode::BinOp testBinOp = ir::OpCode::BinOp::ADD;
+
+    // std::cout << "testBinOp=" << testBinOp << std::endl;
+
+    // ASSERT_EQ(testBinOp, ir::OpCode::BinOp::ADD);
+}

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -1,0 +1,8 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) 
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Added the test structure back in, and cleaned up the code format. The standard form for the dereferencing arrow operator does not have spaces around it. Please merge into the master branch before making other changes.